### PR TITLE
Fix error in options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Options can be passed along as an object containing the following fields:
 .pipe(todo({
     fileName: 'todo.md',
     newLine: '\n',
-    logToConsole: false
+    verbose: false
 }))
 //...
 ```


### PR DESCRIPTION
Option name in example was `logToConsole` instead of `verbose`
