### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,22 @@
 'use strict';
 var path = require('path');
-var gutil = require('gulp-util');
 var through = require('through2');
 var leasot = require('leasot');
 var defaults = require('lodash.defaults');
 var omit = require('lodash.omit');
+var colors = require('ansi-colors');
+var fancyLog = require('fancy-log');
+var PluginError = require('plugin-error');
+var Vinyl = require('vinyl');
 
-var PluginError = gutil.PluginError;
 var pluginName = 'gulp-todo';
 
 function logCommentsToConsole(comments) {
     comments.forEach(function (comment) {
         var isTodo = /todo/i.test(comment.kind);
-        var commentType = isTodo ? gutil.colors.cyan(comment.kind) : gutil.colors.magenta(comment.kind);
-        var commentLocation = '@' + gutil.colors.gray(comment.file + ':' + comment.line);
-        gutil.log(commentType, comment.text, commentLocation);
+        var commentType = isTodo ? colors.cyan(comment.kind) : colors.magenta(comment.kind);
+        var commentLocation = '@' + colors.gray(comment.file + ':' + comment.line);
+        fancyLog(commentType, comment.text, commentLocation);
     });
 }
 
@@ -46,15 +48,15 @@ module.exports = function (options) {
             //check if parser for filetype exists
             if (!leasot.isExtSupported(ext)) {
                 if (!options.skipUnsupported) {
-                    var msg = ['File:', file.path, '- Extension', gutil.colors.red(ext),
+                    var msg = ['File:', file.path, '- Extension', colors.red(ext),
                         'is not supported'
                     ].join(' ');
                     cb(new PluginError(pluginName, msg));
                     return;
                 } else if (options.verbose) {
                     var msg = ['Skipping file', file.path, 'with extension',
-                                    gutil.colors.red(ext), 'as it is unsupported'].join(' ');
-                    gutil.log(msg);
+                                    colors.red(ext), 'as it is unsupported'].join(' ');
+                    fancyLog(msg);
                 }
                 cb();
                 return;
@@ -87,11 +89,11 @@ module.exports = function (options) {
             try {
                 newContents = leasot.reporter(comments, config);
             } catch (e) {
-                cb(new gutil.PluginError(pluginName, e));
+                cb(new PluginError(pluginName, e));
                 return;
             }
 
-            var todoFile = new gutil.File({
+            var todoFile = new Vinyl({
                 cwd: firstFile.cwd,
                 base: firstFile.base,
                 path: path.join(firstFile.base, options.fileName),

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,9 +1,8 @@
 'use strict';
 var path = require('path');
-var gutil = require('gulp-util');
 var through = require('through2');
 var leasot = require('leasot');
-var PluginError = gutil.PluginError;
+var PluginError = require('plugin-error');
 var pluginName = 'gulp-todo';
 
 module.exports = function (reporter, options) {
@@ -31,7 +30,7 @@ module.exports = function (reporter, options) {
             try {
                 newContents = leasot.reporter(file.todos, options);
             } catch (e) {
-                cb(new gutil.PluginError(pluginName, e));
+                cb(new PluginError(pluginName, e));
                 return;
             }
 

--- a/package.json
+++ b/package.json
@@ -34,11 +34,14 @@
     "ci"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.8",
+    "ansi-colors": "^1.0.1",
+    "fancy-log": "^1.3.2",
     "leasot": "^4.7.0",
     "lodash.defaults": "^4.2.0",
     "lodash.omit": "^4.5.0",
-    "through2": "^2.0.3"
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.3",
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/tests/stream-spec.js
+++ b/tests/stream-spec.js
@@ -3,12 +3,12 @@
 var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var todo = require('../index');
 
 var streamFile = function (filename, stream) {
     var testFile = fs.readFileSync(filename);
-    stream.write(new gutil.File({
+    stream.write(new Vinyl({
         path: filename,
         contents: new Buffer(testFile.toString())
     }));
@@ -132,7 +132,7 @@ describe('gulp-todo streaming', function () {
         var file = './index.js';
         var testFile = fs.readFileSync(file);
 
-        stream.write(new gutil.File({
+        stream.write(new Vinyl({
             path: './index.unsupported',
             contents: new Buffer(testFile.toString())
         }));
@@ -159,7 +159,7 @@ describe('gulp-todo streaming', function () {
         var file = './index.js';
         var testFile = fs.readFileSync(file);
 
-        stream.write(new gutil.File({
+        stream.write(new Vinyl({
             path: './index.unsupported',
             contents: new Buffer(testFile.toString())
         }));
@@ -187,7 +187,7 @@ describe('gulp-todo streaming', function () {
         var file = './index.js';
         var testFile = fs.readFileSync(file);
 
-        stream.write(new gutil.File({
+        stream.write(new Vinyl({
             path: './index.unsupported',
             contents: new Buffer(testFile.toString())
         }));


### PR DESCRIPTION
[`gulp-util`](https://www.npmjs.com/package/gulp-util) has been deprecated recently. Continuing to use this dependency may prevent the use of your library with the recently released version 4 of Gulp, **it is important to replace `gulp-util`**.

Your package is popular but still relying on `gulp-util`, it would be good to publish a fixed version to npm as soon as possible.

See:
- https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
- https://github.com/gulpjs/gulp-util/issues/143